### PR TITLE
Replaced plugin usages as per recommendations

### DIFF
--- a/no_sensor/dags/backup_vm_instance.py
+++ b/no_sensor/dags/backup_vm_instance.py
@@ -18,9 +18,9 @@
 import datetime
 from airflow import DAG
 from airflow.models import Variable
-from airflow.operators import SnapshotDiskOperator
-from airflow.operators import StartInstanceOperator
-from airflow.operators import StopInstanceOperator
+from gcp_custom_ops.gce_commands import SnapshotDiskOperator
+from gcp_custom_ops.gce_commands import StartInstanceOperator
+from gcp_custom_ops.gce_commands import StopInstanceOperator
 from airflow.operators.dummy_operator import DummyOperator
 # [END dag_imports]
 

--- a/no_sensor/dags/gcp_custom_ops/gce_commands.py
+++ b/no_sensor/dags/gcp_custom_ops/gce_commands.py
@@ -19,7 +19,6 @@ import datetime
 import logging
 import time
 from airflow.models import BaseOperator
-from airflow.plugins_manager import AirflowPlugin
 from airflow.utils.decorators import apply_defaults
 import googleapiclient.discovery
 from oauth2client.client import GoogleCredentials
@@ -112,11 +111,3 @@ class StartInstanceOperator(BaseOperator):
         project=self.project, zone=self.zone, instance=self.instance).execute()
     time.sleep(20)
     # [END start_oper_no_xcom]
-
-
-class GoogleComputeEnginePlugin(AirflowPlugin):
-  """Expose Airflow operators."""
-
-  name = 'gce_commands_plugin'
-  operators = [StopInstanceOperator, SnapshotDiskOperator,
-               StartInstanceOperator]

--- a/sensor/dags/backup_vm_instance.py
+++ b/sensor/dags/backup_vm_instance.py
@@ -17,7 +17,7 @@
 import datetime
 from airflow import DAG
 from airflow.models import Variable
-from airflow.operators import OperationStatusSensor
+from gcp_custom_ops.gce_commands import OperationStatusSensor
 from gcp_custom_ops.gce_commands import SnapshotDiskOperator
 from gcp_custom_ops.gce_commands import StartInstanceOperator
 from gcp_custom_ops.gce_commands import StopInstanceOperator

--- a/sensor/dags/backup_vm_instance.py
+++ b/sensor/dags/backup_vm_instance.py
@@ -18,9 +18,9 @@ import datetime
 from airflow import DAG
 from airflow.models import Variable
 from airflow.operators import OperationStatusSensor
-from airflow.operators import SnapshotDiskOperator
-from airflow.operators import StartInstanceOperator
-from airflow.operators import StopInstanceOperator
+from gcp_custom_ops.gce_commands import SnapshotDiskOperator
+from gcp_custom_ops.gce_commands import StartInstanceOperator
+from gcp_custom_ops.gce_commands import StopInstanceOperator
 from airflow.operators.dummy_operator import DummyOperator
 
 INTERVAL = '@daily'

--- a/sensor/dags/gcp_custom_ops/gce_commands.py
+++ b/sensor/dags/gcp_custom_ops/gce_commands.py
@@ -18,7 +18,6 @@ import datetime
 import logging
 from airflow.models import BaseOperator
 from airflow.operators.sensors import BaseSensorOperator
-from airflow.plugins_manager import AirflowPlugin
 from airflow.utils.decorators import apply_defaults
 import googleapiclient.discovery
 from oauth2client.client import GoogleCredentials
@@ -143,11 +142,3 @@ class OperationStatusSensor(BaseSensorOperator):
     else:
       logging.info("Waiting for task '%s' to complete", self.prior_task_id)
       return False
-
-
-class GoogleComputeEnginePlugin(AirflowPlugin):
-  """Expose Airflow operators and sensor."""
-
-  name = 'gce_commands_plugin'
-  operators = [StopInstanceOperator, SnapshotDiskOperator,
-               StartInstanceOperator, OperationStatusSensor]


### PR DESCRIPTION
Moved and refactored code to replace usage of airflow plugins for operators, with standard python modules imports, as recommended by airflow documentation (https://airflow.apache.org/docs/apache-airflow/stable/plugins.html)

The documentation suggests to use custom operators as standard python modules imports, not using plugins, as this functionality will be deprecated in version 2.0. 

To comply with this recommendation, this PR:
1. moves the custom operators to a subfolder inside the `dags` folder, as we should not use the plugins folder
2. remove the usage of the plugin system